### PR TITLE
style(commit-template): update template format

### DIFF
--- a/.git-message-template
+++ b/.git-message-template
@@ -1,8 +1,3 @@
-# Yo!
-#
-# We aim to keep our git history clean, maintable and easy to access for all
-# our contributors. Commit messages are very important, which is why we have
-# a commit message policy in place.
 # Please use the following guidelines to format your commit messages:
 #
 #    <type>(<scope>): <subject>
@@ -12,31 +7,28 @@
 #    <footer>
 #
 # Please note that:
-#  - The HEADER is a single line of max. 50 characters that contains a
-#    succinct description of the change. It contains type, an optional
-#    scope, and a subject
-#      + <type> describes the kind of change that this commit is
-#               providing. Allowed types are:
-#            * feat (feature)
-#            * fix (bug fix)
-#            * docs (documentation)
-#            * style (formatting, missing semicolons, ...)
-#            * refactor
-#            * test (when adding missing tests)
-#            * chore (maintain)
-#      + <scope> can be anything specifying the place of the commit
-#                change.
-#      + <subject> is a very short description of the change, in
-#                  the following format:
-#            * imperative, present tense: "change" not
-#              "changed"/"changes"
-#            * no capitalised first letter
-#            * no dot (.) at the end
-#  - The BODY should include the motivation for the change and
-#    contrast this with previous behaviour and must be phrased
-#    in imperative present tense
-#  - The FOOTER should contain any information about Breaking
-#    Changes and is also the place to refernce GitHub issues
-#    that this commit closes
+#  - HEADER: a single line of max. 50 characters that contains a succinct
+#            description of the change. It contains type, an optional scope,
+#            and a subject
+#      + <type> describes the kind of change that this commit is providing.
+#               Allowed types are:
+#                 * feat (feature)
+#                 * fix (bug fix)
+#                 * docs (documentation)
+#                 * style (formatting, missing semicolons, ...)
+#                 * refactor
+#                 * test (when adding missing tests)
+#                 * chore (maintain)
+#      + <scope> specifies the place of the commit change.
+#      + <subject> a very short description of the change.
+#                  Use the following format:
+#                    * imperative, present tense: "change" not
+#                      "changed"/"changes"
+#                    * no capitalised first letter
+#                    * no dot (.) at the end
 #
-# Thank you!
+#  - BODY: describe the motivation for the change and contrast it with previous
+#          behaviour. Use imperative present tense
+#
+#  - FOOTER: information about Breaking Changes and also a place to reference
+#            GitHub issues that this commit closes


### PR DESCRIPTION
stripped out the redundant text from the commit template