### PR TITLE
fix(core/model.py): velocity model input headers

### DIFF
--- a/QMigrate/core/model.py
+++ b/QMigrate/core/model.py
@@ -1347,7 +1347,7 @@ class LUT(Grid3D, NonLinLoc):
 
         call(["rm", "-rf", "control.in", "time", "model"])
 
-    def compute_1d_vmodel_skfmm(self, path, delimiter=","):
+    def compute_1d_vmodel_skfmm(self, path, header=False, delimiter=","):
         """
         Calculate the travel-time tables for each station in a velocity model
         that varies with depth
@@ -1365,7 +1365,10 @@ class LUT(Grid3D, NonLinLoc):
 
         import pandas as pd
 
-        vmod = pd.read_csv(path, delimiter=delimiter).values
+        if header:
+            vmod = pd.read_csv(path, delimiter=delimiter).values
+        else:
+            vmod = pd.read_csv(path, header=None, delimiter=delimiter).values
         z, vp, vs = vmod[:, 0], vmod[:, 1] * 1000, vmod[:, 2] * 1000
 
         rloc = self.station_xyz()


### PR DESCRIPTION
The reading of the velocity model was incorrectly assuming that there
was a header line in the input file. Optional argument added to function
that allows the user to specify whether the velocity model file has a
header line or not.