### PR TITLE
fix(signal/scan.py): final timestep

### DIFF
--- a/QMigrate/signal/scan.py
+++ b/QMigrate/signal/scan.py
@@ -881,8 +881,13 @@ class SeisScan(DefaultSeisScan):
         self.pre_pad += round(t_length * 0.06)
         self.post_pad += round(t_length * 0.06)
 
-        i = 0
-        while start_time + self.time_step * (i + 1) <= end_time:
+        try:
+            nsteps = int(np.ceil((end_time - start_time) / self.time_step))
+        except AttributeError:
+            msg = "Time step has not been specified"
+            print(msg)
+
+        for i in range(nsteps):
             w_beg = start_time + self.time_step * i - self.pre_pad
             w_end = start_time + self.time_step * (i + 1) + self.post_pad
 
@@ -911,7 +916,7 @@ class SeisScan(DefaultSeisScan):
                                                           self.sampling_rate)
 
             del daten, dsnr, dsnr_norm, dloc, map_
-            i += 1
+
         print("=" * 126)
 
     def _compute(self, w_beg, w_end, signal, station_availability):


### PR DESCRIPTION
If the timespan for detect was not an integer multiple the timstep, the final
timestep was being missed off as the endtime was seen as a strict limit
(in a while st + x < et loop). To rectify this problem, we now take the
integer ceiling of (et - st) / time_step and for loop this many times.