### PR TITLE
feat(io;scan;plot): Output directory restructure

### DIFF
--- a/QMigrate/plot/quakeplot.py
+++ b/QMigrate/plot/quakeplot.py
@@ -261,7 +261,7 @@ class QuakePlot:
             if output_file is None:
                 plt.show()
             else:
-                fname = "{}_CoalescenceTrace_{}.pdf"
+                fname = "{}_{}.pdf"
                 fname = fname.format(output_file, station)
                 plt.savefig(fname)
                 plt.close("all")
@@ -542,7 +542,7 @@ class QuakePlot:
             plt.show()
         else:
             fig.suptitle("Event Origin Time = {}".format(dt_max.datetime))
-            plt.savefig("{}_EventLocationError.pdf".format(output_file),
+            plt.savefig("{}_EventSummary.pdf".format(output_file),
                         dpi=400)
             plt.close("all")
 


### PR DESCRIPTION
Restructure the output directory to make them easier to navigate. Now
you specify the output directory and a run name, and it will spawn a new
directory with the following structure:
run
 |_events
 |_logs
 |_mseed
 |_picks
 |_summaries
 |_traces
 |_videos
 |_run.scnmseed file

May require relabelling of detect runs performed prior to 6/6/2018.