### PR TITLE
feat(scan.py): Added the flexibility to choose an input file for locate

### DIFF
--- a/QMigrate/io/quakeio.py
+++ b/QMigrate/io/quakeio.py
@@ -415,7 +415,7 @@ class QuakeIO:
         fname = str(fname.with_suffix(".event"))
         event.to_csv(fname, index=False)
 
-    def read_triggered_events(self, start_time, end_time):
+    def read_triggered_events_time(self, start_time, end_time):
         """
         Read triggered events output by trigger() from csv file.
 
@@ -442,6 +442,30 @@ class QuakeIO:
         events = events[(events["CoaTime"] >= start_time) &
                         (events["CoaTime"] <= end_time)]
 
+        events["MinTime"] = events["MinTime"].apply(UTCDateTime)
+        events["MaxTime"] = events["MaxTime"].apply(UTCDateTime)
+
+        return events
+
+    def read_triggered_events(self, fname):
+        """
+        Read triggered events output by trigger() from csv file.
+
+        Parameters
+        ----------
+        filename : str
+
+        Returns
+        -------
+        events : pandas DataFrame
+            Triggered events output from _trigger_scn().
+            Columns: ["EventNum", "CoaTime", "COA_V", "COA_X", "COA_Y",
+                      "COA_Z", "MinTime", "MaxTime"]
+
+        """
+        events = pd.read_csv(fname)
+
+        events["CoaTime"] = events["CoaTime"].apply(UTCDateTime)
         events["MinTime"] = events["MinTime"].apply(UTCDateTime)
         events["MaxTime"] = events["MaxTime"].apply(UTCDateTime)
 

--- a/QMigrate/plot/triggered_events.py
+++ b/QMigrate/plot/triggered_events.py
@@ -23,7 +23,7 @@ import QMigrate.util as util
 
 def triggered_events(events, start_time, end_time, output, marginal_window,
                      detection_threshold, normalise_coalescence, log,
-                     data=None, stations=None, savefig=False):
+                     data=None, region=None, stations=None, savefig=False):
     """
     Plots the data from a .scanmseed file with annotations illustrating the
     trigger results: event triggers and marginal windows on the coalescence

--- a/example_running_scripts/locate.py
+++ b/example_running_scripts/locate.py
@@ -51,4 +51,5 @@ scan.plot_coal_video = False
 scan.write_cut_waveforms = True
 
 # Run locate
-scan.locate(start_time, end_time)
+scan.locate(start_time=start_time, end_time=end_time)
+# scan.locate(fname="filename_of_triggered_events")


### PR DESCRIPTION
	Added a feature such that locate can be run with a start time
and end time (as was the default before) or that you can pass a
filename through locate. The locate.py script in the example running
scripts directory has also been updated.
New locate function call is
def locate(fname=None, start_time=None, end_time=None):